### PR TITLE
ci(.github/dependabot.yaml): switch npm ecosystem to bun

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,16 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci"
     groups:
       github-actions:
         patterns:
           - "*"
 
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
     groups:
-      npm:
+      bun:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Switches the Dependabot configuration from the `npm` ecosystem to `bun`. The previous setting updated `package.json` plus npm, yarn, or pnpm lockfiles but never regenerated `bun.lock`, which left lockfile bumps inconsistent with how this repo actually installs.

## Why

PR #11 ([Dependabot: `awesome-lint` 0.18.6 → 2.3.0](https://github.com/coder/awesome-coder/pull/11)) failed CI on `bun install --frozen-lockfile` because the lockfile was untouched while `package.json` had been bumped. Dependabot has supported the `bun` ecosystem since [it went GA in February 2025](https://github.blog/changelog/2025-02-19-dependabot-version-updates-now-support-bun/) and writes the text `bun.lock` format used here (Bun 1.1.39+), so this is the targeted fix.

This supersedes PR #13 (the Renovate migration)

## Changes

- `package-ecosystem: "npm"` → `package-ecosystem: "bun"`
- Group name renamed from `npm` to `bun`
- Added `commit-message.prefix` so Dependabot PRs land with conventional prefixes:
  - GitHub Actions group → `ci: bump <action>`
  - Bun group → `chore(deps): bump <package>`

## Verification

- `bun fmt:ci` (Prettier) — clean
- `bun lint` (awesome-lint) — clean
- `typos --config .github/typos.toml` — clean
- YAML parses

## Follow-up

After this merges, Dependabot should re-open the `awesome-lint 0.18.6 → 2.3.0` bump on the next weekly run with `bun.lock` regenerated. CI should pass at that point.

<details>
<summary>Decision log</summary>

- Kept the same weekly cadence, root directory, and "group everything" pattern as the existing `github-actions` entry for consistency.
- Did not split production from development dependencies; the package is tiny and a single group keeps PR volume minimal.
- Did not pin `bun-version`; Dependabot defaults to the version declared in `package.json`/`engines` or the latest stable, which matches the repo's current behavior.

</details>

This change was prepared by Coder Agents.
